### PR TITLE
[Feature] trigger event after user is succesfully added to campaign monitor

### DIFF
--- a/src/events/ApiResponseEvent.php
+++ b/src/events/ApiResponseEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace statikbe\campaignmonitor\events;
+
+use yii\base\Event;
+
+class ApiResponseEvent extends Event
+{
+    public array $response;
+    public string $listId;
+    public array $subscriber;
+}


### PR DESCRIPTION
### Description

For a project I need to do some actions via an event listener after a contact is synced to campaign monitor. 

### Reason for this change

I think its healthier to create an event to listen for over rewriting the controller of campaign monitor in my project. 